### PR TITLE
Add dynamic config selection for Kubernetes client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,2 +1,5 @@
 go 1.21
+
 module github.com/JeremyPDonahue/kubesimulate
+
+require k8s.io/client-go v0.29.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+k8s.io/client-go v0.29.2 h1:FEg85el1TeZp+/vYJM7hkDlSTFZ+c5nnK44DJ4FyoRg=
+k8s.io/client-go v0.29.2/go.mod h1:knlvFZE58VpqbQpJNbCbctTVXcd35mMyAAwBdpt4jrA=

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	"flag"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+// InitializeClient initializes a Kubernetes client using the default kubeconfig
+func InitializeClient() (*kubernetes.Clientset, error) {
+	var config *rest.Config
+	var err error
+
+	// Try to use in-cluster config
+	config, err = rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := flag.String("kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "path to kubeconfig file")
+		flag.Parse()
+
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load kubeconfig: %w", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	return clientset, nil
+}


### PR DESCRIPTION
Implement dynamic Kubernetes config selection for in/out-cluster:

This commit introduces the ability to dynamically select the appropriate Kubernetes configuration method based on the environment context. It enables the application to authenticate with Kubernetes using in-cluster configuration when running inside a pod and will fallback to the kubeconfig file when running outside the cluster.

This enhancement supports flexible deployment and development workflows, making KubeSimulate adaptable for both local development and in-cluster execution.